### PR TITLE
fix empty archive files and usage of ignore-errors flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Flags:
       --ca-file string     verify certificates of HTTPS-enabled servers using this CA bundle
       --cert-file string   identify HTTPS client using this SSL certificate file
   -h, --help               help for mirror
+  -i, --ignore-errors      ignores errors while downloading or processing charts
       --key-file string    identify HTTPS client using this SSL key file
       --new-root-url       New root url of the chart repository (eg: `https://mirror.local.lan/charts`)
       --password string    chart repository password

--- a/cmd/inspectImages.go
+++ b/cmd/inspectImages.go
@@ -27,10 +27,8 @@ import (
 )
 
 var (
-	//IgnoreErrors ignores errors in processing charts
-	IgnoreErrors bool
-	output       string
-	target       string
+	output string
+	target string
 )
 
 const imagesDesc = `Extract all the images of the Helm Chart or
@@ -78,7 +76,7 @@ var inspectImagesCmd = &cobra.Command{
 }
 
 func init() {
-	inspectImagesCmd.PersistentFlags().BoolVarP(&IgnoreErrors, "ignore-errors", "i", false, "ignores errors whiles processing charts. (Exit Code: 2)")
+
 	inspectImagesCmd.PersistentFlags().StringVarP(&output, "output", "o", "stdout", outputDesc)
 	rootCmd.AddCommand(inspectImagesCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,18 +30,20 @@ import (
 
 var (
 	//Verbose defines if the command is being run with verbose mode
-	Verbose    bool
-	folder     string
-	repoURL    *url.URL
-	flags      = log.Ldate | log.Lmicroseconds | log.Lshortfile
-	prefix     = "helm-mirror: "
-	logger     *log.Logger
-	username   string
-	password   string
-	caFile     string
-	certFile   string
-	keyFile    string
-	newRootURL string
+	Verbose bool
+	//IgnoreErrors ignores errors in processing charts
+	IgnoreErrors bool
+	folder       string
+	repoURL      *url.URL
+	flags        = log.Ldate | log.Lmicroseconds | log.Lshortfile
+	prefix       = "helm-mirror: "
+	logger       *log.Logger
+	username     string
+	password     string
+	caFile       string
+	certFile     string
+	keyFile      string
+	newRootURL   string
 )
 
 const rootDesc = `Mirror Helm Charts from an index file into a local folder.
@@ -103,7 +105,7 @@ func Execute() {
 func init() {
 	logger = log.New(os.Stdout, prefix, flags)
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
-
+	rootCmd.PersistentFlags().BoolVarP(&IgnoreErrors, "ignore-errors", "i", false, "ignores errors while downloading or processing charts")
 	rootCmd.Flags().StringVar(&username, "username", "", "chart repository username")
 	rootCmd.Flags().StringVar(&password, "password", "", "chart repository password")
 	rootCmd.Flags().StringVar(&caFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,13 +3,12 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
-	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"testing"
 
+	"github.com/openSUSE/helm-mirror/fixtures"
 	"github.com/spf13/cobra"
 )
 
@@ -54,30 +53,35 @@ func Test_runRoot(t *testing.T) {
 		t.Errorf("creating temp dir: %s", err)
 	}
 	defer os.RemoveAll(dir)
-	svr := startHTTPServer()
+	svr := fixtures.StartHTTPServer()
+	fixtures.WaitForServer(svr.Addr)
 	type args struct {
-		cmd        *cobra.Command
-		args       []string
-		newRootURL string
+		cmd          *cobra.Command
+		args         []string
+		newRootURL   string
+		ignoreErrors bool
 	}
 	tests := []struct {
 		name    string
 		args    args
 		wantErr bool
 	}{
-		{"1", args{&cobra.Command{}, []string{"http://test", path.Join("/mr", "mzxyptlk")}, ""}, true},
-		{"2", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, ""}, false},
-		{"3", args{&cobra.Command{}, []string{"%", dir}, ""}, true},
-		{"4", args{&cobra.Command{}, []string{"http://test", dir}, "%"}, true},
-		{"5", args{&cobra.Command{}, []string{"http://test", dir}, "ftp://test"}, true},
-		{"6", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "https://test/com/charts"}, false},
-		{"7", args{&cobra.Command{}, []string{"http://127.0.0.1:1111", dir}, "https://test/com/charts"}, true},
+		{"1", args{&cobra.Command{}, []string{"http://test", path.Join("/mr", "mzxyptlk")}, "", false}, true},
+		{"2", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "", true}, false},
+		{"3", args{&cobra.Command{}, []string{"%", dir}, "", false}, true},
+		{"4", args{&cobra.Command{}, []string{"http://test", dir}, "%", false}, true},
+		{"5", args{&cobra.Command{}, []string{"http://test", dir}, "ftp://test", false}, true},
+		{"6", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "https://test/com/charts", true}, false},
+		{"7", args{&cobra.Command{}, []string{"http://127.0.0.1:1111", dir}, "https://test/com/charts", false}, true},
+		{"8", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir, "--ignore-errors"}, "https://test/com/charts", true}, false},
+		{"9", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "", false}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fmt.Printf("%s clean\n", filepath.Clean(dir))
 			fmt.Printf("%v\n", tt.args.args[1])
 			newRootURL = tt.args.newRootURL
+			IgnoreErrors = tt.args.ignoreErrors
 			if err := runRoot(tt.args.cmd, tt.args.args); (err != nil) != tt.wantErr {
 				t.Errorf("runRoot() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -87,60 +91,3 @@ func Test_runRoot(t *testing.T) {
 		t.Errorf("error stoping down web server")
 	}
 }
-
-func startHTTPServer() *http.Server {
-	srv := &http.Server{Addr: ":1793"}
-	http.HandleFunc("/index.yaml", indexFile)
-	http.HandleFunc("/chart1-2.11.0.tgz", chartTgz)
-	http.HandleFunc("/chart2-1.0.1.tgz", chartTgz)
-	http.HandleFunc("/chart2-0.0.0-pre.tgz", chartTgz)
-	go func() {
-		if err := srv.ListenAndServe(); err != nil {
-			log.Printf("Httpserver: ListenAndServe() error: %s", err)
-		}
-	}()
-	return srv
-}
-
-func indexFile(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "binary/octet-stream")
-	w.Write(indexYaml)
-}
-
-func chartTgz(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "binary/octet-stream")
-	w.Write(chartTGZ)
-}
-
-var indexYaml = []byte(`apiVersion: v1
-entries:
-  chart1:
-  - apiVersion: v2
-    created: 2018-09-20T00:00:00.000000000Z
-    description: A Helm chart for testing
-    digest: 8cc99f9cb669171776f7c6ec66069907579be91179f9201725fc6fc6f9ef1f29
-    name: chart1
-    urls:
-    - http://127.0.0.1:1793/chart1-2.11.0.tgz
-    version: 2.11.0
-  chart2:
-  - apiVersion: v1
-    created: 2018-09-20T00:00:00.000000000Z
-    description: A Helm chart for testing too
-    digest: 0c76ee9b4b78cb60fcce8c00ec0f5048cbe626fcaabe48f2f8e84b029e894f49
-    name: chart2
-    urls:
-    - http://127.0.0.1:1793/chart2-1.0.1.tgz
-    version: 1.0.1
-  - apiVersion: v1
-    created: 2018-09-20T00:00:00.000000000Z
-    description: A Helm chart for testing too
-    digest: e9a545006570b7fc5e4458f6eae178c2aa8f8e9e57eafac59869c856b86e862f
-    name: chart2
-    urls:
-    - http://127.0.0.1:1793/chart2-0.0.0-pre.tgz
-    version: 0.0.0-pre
-`)
-
-var chartTGZ = []byte{31, 139, 8, 0, 224, 223, 181, 91, 0, 3, 237, 193, 1, 13, 0, 0, 0, 194,
-	160, 247, 79, 109, 14, 55, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 55, 3, 154, 222, 29, 39, 0, 40, 0, 0}

--- a/doc/man/helm-mirror-inspect-images.1.md
+++ b/doc/man/helm-mirror-inspect-images.1.md
@@ -28,7 +28,7 @@ option.
   Print usage statement.
 
 **-i, --ignore-errors**
-  Ignores errors whiles processing charts. (Exit Code: 2)
+  Ignores errors while downloading or processing charts.
 
 **-o, --output**
   choose an output for the list of images and specify the file name, if not specified 'images.out' will be the default.

--- a/doc/man/helm-mirror.1.md
+++ b/doc/man/helm-mirror.1.md
@@ -75,6 +75,9 @@ into your destination folder.
 **--cert-file**
   Identify HTTPS client using this SSL certificate file
 
+**-i, --ignore-errors**
+  Ignores errors while downloading or processing charts.
+
 **--key-file**
   Identify HTTPS client using this SSL key file
 

--- a/fixtures/test_utils.go
+++ b/fixtures/test_utils.go
@@ -1,0 +1,92 @@
+package fixtures
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+// StartHTTPServer start http server for tests
+func StartHTTPServer() *http.Server {
+	srv := &http.Server{Addr: ":1793"}
+	http.HandleFunc("/index.yaml", indexFile)
+	http.HandleFunc("/chart1-2.11.0.tgz", chartTgz)
+	http.HandleFunc("/chart2-1.0.1.tgz", chartTgz)
+	http.HandleFunc("/chart2-0.0.0-pre.tgz", chartTgz)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil {
+			log.Printf("Httpserver: ListenAndServe() error: %s", err)
+		}
+	}()
+	return srv
+}
+
+// WaitForServer waits until the server is up
+func WaitForServer(url string) {
+	var retry = 10
+	for i := 0; i < retry; i++ {
+		resp, err := http.Get(url)
+		if err != nil {
+			time.Sleep(2)
+			continue
+		}
+		if resp.StatusCode == http.StatusOK {
+			return
+		}
+	}
+}
+
+func indexFile(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "binary/octet-stream")
+	w.Write([]byte(IndexYaml))
+}
+
+func chartTgz(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "binary/octet-stream")
+	w.Write(chartTGZ)
+}
+
+var chartTGZ = []byte{31, 139, 8, 0, 224, 223, 181, 91, 0, 3, 237, 193, 1, 13, 0, 0, 0, 194,
+	160, 247, 79, 109, 14, 55, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 55, 3, 154, 222, 29, 39, 0, 40, 0, 0}
+
+//Expectedcharts How many charts are in the test file
+var Expectedcharts = 4
+
+//IndexYaml test index file
+var IndexYaml = `apiVersion: v1
+entries:
+  chart1:
+  - apiVersion: v2
+    created: 2018-09-20T00:00:00.000000000Z
+    description: A Helm chart for testing
+    digest: 8cc99f9cb669171776f7c6ec66069907579be91179f9201725fc6fc6f9ef1f29
+    name: chart1
+    urls:
+    - http://127.0.0.1:1793/chart1-2.11.0.tgz
+    version: 2.11.0
+  chart2:
+  - apiVersion: v1
+    created: 2018-09-20T00:00:00.000000000Z
+    description: A Helm chart for testing too
+    digest: 0c76ee9b4b78cb60fcce8c00ec0f5048cbe626fcaabe48f2f8e84b029e894f49
+    name: chart2
+    urls:
+    - http://127.0.0.1:1793/chart2-1.0.1.tgz
+    version: 1.0.1
+  - apiVersion: v1
+    created: 2018-09-20T00:00:00.000000000Z
+    description: A Helm chart for testing too
+    digest: e9a545006570b7fc5e4458f6eae178c2aa8f8e9e57eafac59869c856b86e862f
+    name: chart2
+    urls:
+    - http://127.0.0.1:1793/chart2-0.0.0-pre.tgz
+    version: 0.0.0-pre
+  - apiVersion: v1
+    created: 2018-12-18T00:00:00.000000000Z
+    description: A Helm chart that does not exist
+    digest: f9a848106870c7fc8f4488f6faf178c2aa8f8f9f87fafac89819c886c86e862f
+    name: chart3
+    urls:
+    - http://127.0.0.1:1793/chart3-0.0.1-pre.tgz
+    version: 0.0.1-pre
+`

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -8,7 +8,7 @@ mode=atomic
 rm -rf "$workdir"
 mkdir "$workdir"
 
-for d in $(go list ./... | grep -v vendor); do
+for d in $(go list ./... | grep -v -E "vendor|fixtures"); do
     f="$workdir/$(echo $d | tr / -).cover"
     go test -covermode="$mode" -coverprofile="$f" $d
 done

--- a/service/mocks_test.go
+++ b/service/mocks_test.go
@@ -18,36 +18,6 @@ func (m *mockFormatter) Output(buffer bytes.Buffer) error {
 	return nil
 }
 
-var indexYaml = `apiVersion: v1
-entries:
-  chart1:
-  - apiVersion: v2
-    created: 2018-09-20T00:00:00.000000000Z
-    description: A Helm chart for testing
-    digest: 8cc99f9cb669171776f7c6ec66069907579be91179f9201725fc6fc6f9ef1f29
-    name: chart1
-    urls:
-    - http://127.0.0.1:1793/chart1-2.11.0.tgz
-    version: 2.11.0
-  chart2:
-  - apiVersion: v1
-    created: 2018-09-20T00:00:00.000000000Z
-    description: A Helm chart for testing too
-    digest: 0c76ee9b4b78cb60fcce8c00ec0f5048cbe626fcaabe48f2f8e84b029e894f49
-    name: chart2
-    urls:
-    - http://127.0.0.1:1793/chart2-1.0.1.tgz
-    version: 1.0.1
-  - apiVersion: v1
-    created: 2018-09-20T00:00:00.000000000Z
-    description: A Helm chart for testing too
-    digest: e9a545006570b7fc5e4458f6eae178c2aa8f8e9e57eafac59869c856b86e862f
-    name: chart2
-    urls:
-    - http://127.0.0.1:1793/chart2-0.0.0-pre.tgz
-    version: 0.0.0-pre
-`
-
 var valuesYaml = `---
 kube:
   external_ips: []
@@ -62,6 +32,3 @@ kube:
 image: "opensuse"
 version: "42"
 `
-
-var chartTGZ = []byte{31, 139, 8, 0, 224, 223, 181, 91, 0, 3, 237, 193, 1, 13, 0, 0, 0, 194,
-	160, 247, 79, 109, 14, 55, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 55, 3, 154, 222, 29, 39, 0, 40, 0, 0}


### PR DESCRIPTION
Signed-off-by: Vicente Zepeda Mas <vzepedamas@suse.com>

Fixes a problem that created empty archives for charts that had error when downloading.

Fixes the use of ignore-errors flag for base command.