### PR TITLE
New features: get latest and specific charts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: go
-go:
-- "1.9"
-- "1.10"
 sudo: required
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM opensuse/amd64:42.3
+FROM opensuse/leap:15.1
 
 LABEL Maintainer="SUSE Containers Team <containers@suse.com>"
 
-RUN zypper -n up
 RUN zypper -n in \
 		git \
-		go \
+		go1.12 \
 		golang-github-cpuguy83-go-md2man \
 		make \
-		tar
+		tar \
+		gzip
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -224,9 +224,10 @@
   version = "kubernetes-1.14.1"
 
 [[projects]]
-  digest = "1:020588175b9e5eee86450a8ac85af2bff12169716dc3dcbfbde65f45a98d35b9"
+  digest = "1:9f4d75e17d60644ecd85e7886c1eb9375db2f7d2b9e500211e8c56f32e054431"
   name = "k8s.io/helm"
   packages = [
+    "cmd/helm/search",
     "pkg/chartutil",
     "pkg/engine",
     "pkg/getter",
@@ -257,6 +258,7 @@
     "github.com/pkg/errors",
     "github.com/spf13/cobra",
     "gopkg.in/yaml.v3",
+    "k8s.io/helm/cmd/helm/search",
     "k8s.io/helm/pkg/chartutil",
     "k8s.io/helm/pkg/engine",
     "k8s.io/helm/pkg/getter",

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Go tools.
-GO ?= GO111MODULE=off go
+GO ?= go
 GO_MD2MAN ?= go-md2man
 
 # Paths.

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ GO_SRC = $(shell find . -name \*.go)
 # NOTE: If you change these make sure you also update local-validate-build.
 
 mirror: $(GO_SRC)
-	$(GO) build ${DYN_BUILD_FLAGS} -o $(BUILD_DIR)/$@ ${CMD}
+	$(GO) build ${DYN_BUILD_FLAGS} -o $(BUILD_DIR)/helm-mirror ${CMD}
 
 mirror.static: $(GO_SRC)
-	env CGO_ENABLED=0 $(GO) build ${STATIC_BUILD_FLAGS} -o $(BUILD_DIR)/$@ ${CMD}
+	env CGO_ENABLED=0 $(GO) build ${STATIC_BUILD_FLAGS} -o $(BUILD_DIR)/helm-mirror ${CMD}
 
 install: $(GO_SRC)
 	$(GO) install -v ${DYN_BUILD_FLAGS} ${CMD}
@@ -125,12 +125,12 @@ dist:
 	rm -rf build/mirror/* release/*
 	mkdir -p build/mirror/bin release/
 	cp README.md LICENSE plugin.yaml build/mirror
-	GOOS=linux GOARCH=amd64 go build -o build/mirror/bin/mirror -ldflags="$(BASE_LDFLAGS)"
+	GOOS=linux GOARCH=amd64 go build -o build/mirror/bin/helm-mirror -ldflags="$(BASE_LDFLAGS)"
 	tar -C build/ -zcvf $(CURDIR)/release/helm-mirror-linux.tgz mirror/
-	GOOS=darwin GOARCH=amd64 go build -o build/mirror/bin/mirror -ldflags="$(BASE_LDFLAGS)"
+	GOOS=darwin GOARCH=amd64 go build -o build/mirror/bin/helm-mirror -ldflags="$(BASE_LDFLAGS)"
 	tar -C build/ -zcvf $(CURDIR)/release/helm-mirror-macos.tgz mirror/
-	rm build/mirror/bin/mirror
-	GOOS=windows GOARCH=amd64 go build -o build/mirror/bin/mirror.exe -ldflags="$(BASE_LDFLAGS)"
+	rm build/mirror/bin/helm-mirror
+	GOOS=windows GOARCH=amd64 go build -o build/mirror/bin/helm-mirror.exe -ldflags="$(BASE_LDFLAGS)"
 	tar -C build/ -zcvf $(CURDIR)/release/helm-mirror-windows.tgz mirror/
 
 release: dist

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Helm Mirror Plugin
+# helm-mirror Plugin
 
 [![Release](https://img.shields.io/github/release/openSUSE/helm-mirror.svg)](https://github.com/openSUSE/helm-mirror/releases/latest)
 [![Build Status](https://img.shields.io/travis/openSUSE/helm-mirror/master.svg)](https://travis-ci.org/openSUSE/helm-mirror)
@@ -15,10 +15,10 @@ Mirror Helm Charts from an index file into a local folder.
 
 For example:
 
-`helm mirror https://yourorg.com/charts /yourorg/charts`
+`helm-mirror https://yourorg.com/charts /yourorg/charts`
 
-This will download the index file and the charts into
-the folder indicated.
+This will download the index file and the latest version of the charts
+into the folder indicated.
 
 The index file is a yaml that contains a list of
 charts in this format. Example:
@@ -55,30 +55,52 @@ into your destination folder.
 Usage:
 
 ```
-  helm mirror [Repo URL] [Destination Folder] [flags]
-  helm mirror [command]
+  helm-mirror [Repo URL] [Destination Folder] [flags]
+  helm-mirror [command]
 ```
 
 Available Commands:
   help           Help about any command
   inspect-images Extract all the images of the Helm Charts.
-  version        Show version of the helm mirror plugin
+  version        Show version of the helm-mirror plugin
 
 Flags:
 
 ```
-      --ca-file string     verify certificates of HTTPS-enabled servers using this CA bundle
-      --cert-file string   identify HTTPS client using this SSL certificate file
-  -h, --help               help for mirror
-  -i, --ignore-errors      ignores errors while downloading or processing charts
-      --key-file string    identify HTTPS client using this SSL key file
-      --new-root-url       New root url of the chart repository (eg: `https://mirror.local.lan/charts`)
-      --password string    chart repository password
-      --username string    chart repository username
-  -v, --verbose            verbose output
+  -a, --all-versions                                   gets all the versions of the charts in the chart repository
+      --ca-file string                                 verify certificates of HTTPS-enabled servers using this CA bundle
+      --cert-file string                               identify HTTPS client using this SSL certificate file
+      --chart-name string                              name of the chart that gets mirrored
+      --chart-version string                           specific version of the chart that is going to be mirrored
+  -h, --help                                           help for mirror
+  -i, --ignore-errors                                  ignores errors while downloading or processing charts
+      --key-file string                                identify HTTPS client using this SSL key file
+      --new-root-url https://mirror.local.lan/charts   New root url of the chart repository (eg: https://mirror.local.lan/charts)
+      --password string                                chart repository password
+      --username string                                chart repository username
+  -v, --verbose                                        verbose output
 ```
 
-Use `helm mirror [command] --help` for more information about a command.
+### Getting all charts
+
+`helm-mirror https://yourorg.com/charts /yourorg/charts --all-charts`
+
+This will download all the charts and all the available versions
+of the charts.
+
+### Getting one specific chart
+
+`helm-mirror https://yourorg.com/charts /yourorg/charts --chart-name nginx`
+
+This will download the latest version of the chart `nginx`.
+
+### Getting one specific chart with specific version
+
+`helm-mirror https://yourorg.com/charts /yourorg/charts --chart-name nginx --chart-version 2.14.3`
+
+This will download the version `2.14.3` of the chart `nginx`.
+
+Use `helm-mirror [command] --help` for more information about a command.
 
 ## Commands
 
@@ -89,9 +111,9 @@ the Helm Charts in the folder provided. This command dumps
 the images on `stdout` by default, for more options check
 `output flag`. Example:
 
-- helm mirror inspect-images /tmp/helm
+- helm-mirror inspect-images /tmp/helm
 
-- helm mirror inspect-images /tmp/helm/app.tgz
+- helm-mirror inspect-images /tmp/helm/app.tgz
 
 The [folder|tgzfile] has to be a full path.
 
@@ -116,12 +138,12 @@ The [folder|tgzfile] has to be a full path.
 - yaml: outputs all images to a file in YAML format
 
 ```shell
-helm mirror inspect-images /tmp/helm --output stdout
-helm mirror inspect-images /tmp/helm -o stdout
-helm mirror inspect-images /tmp/helm -o file=filename
-helm mirror inspect-images /tmp/helm -o json=filename.json
-helm mirror inspect-images /tmp/helm -o yaml=filename.yaml
-helm mirror inspect-images /tmp/helm -o skopeo=filename.yaml
+helm-mirror inspect-images /tmp/helm --output stdout
+helm-mirror inspect-images /tmp/helm -o stdout
+helm-mirror inspect-images /tmp/helm -o file=filename
+helm-mirror inspect-images /tmp/helm -o json=filename.json
+helm-mirror inspect-images /tmp/helm -o yaml=filename.yaml
+helm-mirror inspect-images /tmp/helm -o skopeo=filename.yaml
 ```
 
 #### Global Flags

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,18 +34,20 @@ var (
 	//IgnoreErrors ignores errors in processing charts
 	IgnoreErrors bool
 	//AllVersions gets all the versions of the charts when true, false by default
-	AllVersions bool
-	folder      string
-	repoURL     *url.URL
-	flags       = log.Ldate | log.Lmicroseconds | log.Lshortfile
-	prefix      = "helm-mirror: "
-	logger      *log.Logger
-	username    string
-	password    string
-	caFile      string
-	certFile    string
-	keyFile     string
-	newRootURL  string
+	AllVersions  bool
+	chartName    string
+	chartVersion string
+	folder       string
+	repoURL      *url.URL
+	flags        = log.Ldate | log.Lmicroseconds | log.Lshortfile
+	prefix       = "helm-mirror: "
+	logger       *log.Logger
+	username     string
+	password     string
+	caFile       string
+	certFile     string
+	keyFile      string
+	newRootURL   string
 )
 
 const rootDesc = `Mirror Helm Charts from an index file into a local folder.
@@ -108,7 +110,9 @@ func init() {
 	logger = log.New(os.Stdout, prefix, flags)
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&IgnoreErrors, "ignore-errors", "i", false, "ignores errors while downloading or processing charts")
-	rootCmd.PersistentFlags().BoolVarP(&AllVersions, "all-versions", "a", false, "when given gets all the versions of the charts in the chart repository")
+	rootCmd.PersistentFlags().BoolVarP(&AllVersions, "all-versions", "a", false, "gets all the versions of the charts in the chart repository")
+	rootCmd.Flags().StringVar(&chartName, "chart-name", "", "name of the chart that gets mirrored")
+	rootCmd.Flags().StringVar(&chartVersion, "chart-version", "", "specific version of the chart that is going to be mirrored")
 	rootCmd.Flags().StringVar(&username, "username", "", "chart repository username")
 	rootCmd.Flags().StringVar(&password, "password", "", "chart repository password")
 	rootCmd.Flags().StringVar(&caFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
@@ -170,6 +174,11 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if chartVersion != "" && chartName == "" {
+		logger.Printf("error: chart Version depends on a chart name, please specify one")
+		return errors.New("error: chart Version depends on a chart name, please specify one")
+	}
+
 	config := repo.Entry{
 		Name:     folder,
 		URL:      repoURL.String(),
@@ -179,7 +188,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		CertFile: certFile,
 		KeyFile:  keyFile,
 	}
-	getService := service.NewGetService(config, AllVersions, Verbose, IgnoreErrors, logger, rootURL.String())
+	getService := service.NewGetService(config, AllVersions, Verbose, IgnoreErrors, logger, rootURL.String(), chartName, chartVersion)
 	err = getService.Get()
 	if err != nil {
 		return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,17 +33,19 @@ var (
 	Verbose bool
 	//IgnoreErrors ignores errors in processing charts
 	IgnoreErrors bool
-	folder       string
-	repoURL      *url.URL
-	flags        = log.Ldate | log.Lmicroseconds | log.Lshortfile
-	prefix       = "helm-mirror: "
-	logger       *log.Logger
-	username     string
-	password     string
-	caFile       string
-	certFile     string
-	keyFile      string
-	newRootURL   string
+	//AllVersions gets all the versions of the charts when true, false by default
+	AllVersions bool
+	folder      string
+	repoURL     *url.URL
+	flags       = log.Ldate | log.Lmicroseconds | log.Lshortfile
+	prefix      = "helm-mirror: "
+	logger      *log.Logger
+	username    string
+	password    string
+	caFile      string
+	certFile    string
+	keyFile     string
+	newRootURL  string
 )
 
 const rootDesc = `Mirror Helm Charts from an index file into a local folder.
@@ -106,6 +108,7 @@ func init() {
 	logger = log.New(os.Stdout, prefix, flags)
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&IgnoreErrors, "ignore-errors", "i", false, "ignores errors while downloading or processing charts")
+	rootCmd.PersistentFlags().BoolVarP(&AllVersions, "all-versions", "a", false, "when given gets all the versions of the charts in the chart repository")
 	rootCmd.Flags().StringVar(&username, "username", "", "chart repository username")
 	rootCmd.Flags().StringVar(&password, "password", "", "chart repository password")
 	rootCmd.Flags().StringVar(&caFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
@@ -176,7 +179,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		CertFile: certFile,
 		KeyFile:  keyFile,
 	}
-	getService := service.NewGetService(config, Verbose, IgnoreErrors, logger, rootURL.String())
+	getService := service.NewGetService(config, AllVersions, Verbose, IgnoreErrors, logger, rootURL.String())
 	err = getService.Get()
 	if err != nil {
 		return err

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -54,27 +54,33 @@ func Test_runRoot(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 	svr := fixtures.StartHTTPServer()
+	defer svr.Shutdown(nil)
+	fixtures.WaitForServer("http://127.0.0.1:1793/alive")
 	type args struct {
 		cmd          *cobra.Command
 		args         []string
 		newRootURL   string
 		ignoreErrors bool
 		allVersions  bool
+		chartName    string
+		chartVersion string
 	}
 	tests := []struct {
 		name    string
 		args    args
 		wantErr bool
 	}{
-		{"1", args{&cobra.Command{}, []string{"http://test", path.Join("/mr", "mzxyptlk")}, "", false, true}, true},
-		{"2", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "", true, true}, false},
-		{"3", args{&cobra.Command{}, []string{"%", dir}, "", false, true}, true},
-		{"4", args{&cobra.Command{}, []string{"http://test", dir}, "%", false, true}, true},
-		{"5", args{&cobra.Command{}, []string{"http://test", dir}, "ftp://test", false, true}, true},
-		{"6", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "https://test/com/charts", true, true}, false},
-		{"7", args{&cobra.Command{}, []string{"http://127.0.0.1:1111", dir}, "https://test/com/charts", false, true}, true},
-		{"8", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir, "--ignore-errors"}, "https://test/com/charts", true, true}, false},
-		{"9", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "", false, true}, true},
+		{"1", args{&cobra.Command{}, []string{"http://test", path.Join("/mr", "mzxyptlk")}, "", false, true, "", ""}, true},
+		{"2", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "", true, true, "", ""}, false},
+		{"3", args{&cobra.Command{}, []string{"%", dir}, "", false, true, "", ""}, true},
+		{"4", args{&cobra.Command{}, []string{"http://test", dir}, "%", false, true, "", ""}, true},
+		{"5", args{&cobra.Command{}, []string{"http://test", dir}, "ftp://test", false, true, "", ""}, true},
+		{"6", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "https://test/com/charts", true, true, "", ""}, false},
+		{"7", args{&cobra.Command{}, []string{"http://127.0.0.1:1111", dir}, "https://test/com/charts", false, true, "", ""}, true},
+		{"8", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "https://test/com/charts", true, true, "", ""}, false},
+		{"9", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "", false, true, "", ""}, true},
+		{"10", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "", true, false, "", ""}, false},
+		{"11", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "", true, false, "", "1.0.0"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -83,13 +89,11 @@ func Test_runRoot(t *testing.T) {
 			newRootURL = tt.args.newRootURL
 			IgnoreErrors = tt.args.ignoreErrors
 			AllVersions = tt.args.allVersions
-			fixtures.WaitForServer(svr.Addr)
+			chartName = tt.args.chartName
+			chartVersion = tt.args.chartVersion
 			if err := runRoot(tt.args.cmd, tt.args.args); (err != nil) != tt.wantErr {
 				t.Errorf("runRoot() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
-	}
-	if err := svr.Shutdown(nil); err != nil {
-		t.Errorf("error stoping down web server")
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -54,27 +54,27 @@ func Test_runRoot(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 	svr := fixtures.StartHTTPServer()
-	fixtures.WaitForServer(svr.Addr)
 	type args struct {
 		cmd          *cobra.Command
 		args         []string
 		newRootURL   string
 		ignoreErrors bool
+		allVersions  bool
 	}
 	tests := []struct {
 		name    string
 		args    args
 		wantErr bool
 	}{
-		{"1", args{&cobra.Command{}, []string{"http://test", path.Join("/mr", "mzxyptlk")}, "", false}, true},
-		{"2", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "", true}, false},
-		{"3", args{&cobra.Command{}, []string{"%", dir}, "", false}, true},
-		{"4", args{&cobra.Command{}, []string{"http://test", dir}, "%", false}, true},
-		{"5", args{&cobra.Command{}, []string{"http://test", dir}, "ftp://test", false}, true},
-		{"6", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "https://test/com/charts", true}, false},
-		{"7", args{&cobra.Command{}, []string{"http://127.0.0.1:1111", dir}, "https://test/com/charts", false}, true},
-		{"8", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir, "--ignore-errors"}, "https://test/com/charts", true}, false},
-		{"9", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "", false}, true},
+		{"1", args{&cobra.Command{}, []string{"http://test", path.Join("/mr", "mzxyptlk")}, "", false, true}, true},
+		{"2", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "", true, true}, false},
+		{"3", args{&cobra.Command{}, []string{"%", dir}, "", false, true}, true},
+		{"4", args{&cobra.Command{}, []string{"http://test", dir}, "%", false, true}, true},
+		{"5", args{&cobra.Command{}, []string{"http://test", dir}, "ftp://test", false, true}, true},
+		{"6", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "https://test/com/charts", true, true}, false},
+		{"7", args{&cobra.Command{}, []string{"http://127.0.0.1:1111", dir}, "https://test/com/charts", false, true}, true},
+		{"8", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir, "--ignore-errors"}, "https://test/com/charts", true, true}, false},
+		{"9", args{&cobra.Command{}, []string{"http://127.0.0.1:1793", dir}, "", false, true}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -82,6 +82,8 @@ func Test_runRoot(t *testing.T) {
 			fmt.Printf("%v\n", tt.args.args[1])
 			newRootURL = tt.args.newRootURL
 			IgnoreErrors = tt.args.ignoreErrors
+			AllVersions = tt.args.allVersions
+			fixtures.WaitForServer(svr.Addr)
 			if err := runRoot(tt.args.cmd, tt.args.args); (err != nil) != tt.wantErr {
 				t.Errorf("runRoot() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/doc/man/helm-mirror-help.1.md
+++ b/doc/man/helm-mirror-help.1.md
@@ -1,14 +1,14 @@
-% mirror-help(1) # mirror help - Displays the usage statement
+% helm-mirror-help(1) # helm-mirror help - Displays the usage statement
 % SUSE LLC
 % OCTOBER 2018
 # NAME
-mirror help - Displays the usage statement
+helm-mirror help - Displays the usage statement
 
 # SYNOPSIS
-**mirror help**
+**helm-mirror help**
 
 # DESCRIPTION
-**mirror** Displays the usage statement.
+**helm-mirror** Displays the usage statement.
 
 # GLOBAL OPTIONS
 
@@ -19,6 +19,6 @@ mirror help - Displays the usage statement
   Verbose output
 
 # SEE ALSO
-**mirror**(1),
-**mirror-inspect-images**(1),
-**mirror-version**(1)
+**helm-mirror**(1),
+**helm-mirror-inspect-images**(1),
+**helm-mirror-version**(1)

--- a/doc/man/helm-mirror-inspect-images.1.md
+++ b/doc/man/helm-mirror-inspect-images.1.md
@@ -1,19 +1,19 @@
-% mirror-inspect-images(1) # mirror inspect-images - Extract all the container images listed in each chart.
+% helm-mirror-inspect-images(1) # helm-mirror inspect-images - Extract all the container images listed in each chart.
 % SUSE LLC
 % OCTOBER 2018
 # NAME
-mirror inspect-images - Extract all the container images listed in each chart.
+helm-mirror inspect-images - Extract all the container images listed in each chart.
 
 # SYNOPSIS
-**mirror inspect-images** target
+**helm-mirror inspect-images** target
 [**--help**|**-h**]
 
 # DESCRIPTION
-**mirror inspect-images** Extract all the container images listed in each Helm Chart or
+**helm-mirror inspect-images** Extract all the container images listed in each Helm Chart or
 the Helm Charts in the folder provided. This command dumps the images on
 **stdout** by default.
 
-**mirror inspect-images** Has different type of outputs for the images to make
+**helm-mirror inspect-images** Has different type of outputs for the images to make
 it easier to interact with the sub-command, for more options check **output**
 option.
 
@@ -40,30 +40,30 @@ command.
 
 Inspect a folder and print to **stdout** (default for the **--output** option)
 ```
-% helm mirror inspect-images /tmp/helm
+% helm-mirror inspect-images /tmp/helm
 ```
 
 Inspect a chart file and print to **stdout**
 ```
-% helm mirror inspect-images /tmp/helm/chart.tgz
+% helm-mirror inspect-images /tmp/helm/chart.tgz
 ```
 
 Inspect a folder and export to other formats.
 ```
-% helm mirror inspect-images /tmp/helm -o file=images.txt
-% helm mirror inspect-images /tmp/helm -o json=images.json
-% helm mirror inspect-images /tmp/helm -o yaml=images.yaml
+% helm-mirror inspect-images /tmp/helm -o file=images.txt
+% helm-mirror inspect-images /tmp/helm -o json=images.json
+% helm-mirror inspect-images /tmp/helm -o yaml=images.yaml
 ```
 
 Inspect a folder and ignore the errors while rendering the chart, this
 errors are usually for missing required values in the charts.
 ```
-% helm mirror inspect-images /tmp/helm --ignore-errors
+% helm-mirror inspect-images /tmp/helm --ignore-errors
 ```
 
 # SEE ALSO
-**mirror**(1),
-**mirror-help**(1),
-**mirror-version**(1)
+**helm-mirror**(1),
+**helm-mirror-help**(1),
+**helm-mirror-version**(1)
 
 [1]: https://github.com/SUSE/skopeo/blob/sync/docs/skopeo.1.md#skopeo-sync

--- a/doc/man/helm-mirror-version.1.md
+++ b/doc/man/helm-mirror-version.1.md
@@ -1,14 +1,14 @@
-% mirror-version(1) # Version - show program current version
+% helm-mirror-version(1) # Version - show program current version
 % SUSE LLC
 % OCTOBER 2018
 # NAME
-mirror version - show program current version
+helm-mirror version - show program current version
 
 # SYNOPSIS
 [**version**]
 
 # DESCRIPTION
-**mirror version** displays the program version.
+**helm-mirror version** displays the program version.
 
 # GLOBAL OPTIONS
 
@@ -19,6 +19,6 @@ mirror version - show program current version
   Verbose output
 
 # SEE ALSO
-**mirror**(1),
-**mirror-inspect-images**(1),
-**mirror-help**(1)
+**helm-mirror**(1),
+**helm-mirror-inspect-images**(1),
+**helm-mirror-help**(1)

--- a/doc/man/helm-mirror.1.md
+++ b/doc/man/helm-mirror.1.md
@@ -1,16 +1,18 @@
-% mirror(1) # mirror - Mirror chart repositories
+% helm-mirror(1) # helm-mirror - Mirror chart repositories
 % SUSE LLC
 % OCTOBER 2018
 # NAME
-mirror - mirror chart repositories
+helm-mirror - helm-mirror chart repositories
 
 # SYNOPSIS
-**mirror**
+**helm-mirror**
 [**--help**|**-h**]
 [**version**]
 [**inspect-images**]
 [**--ca-file**]
 [**--cert-file**]
+[**--chart-name**]
+[**--chart-version**]
 [**--ignore-errors**]
 [**--key-file**]
 [**--new-root-url**]
@@ -20,15 +22,15 @@ mirror - mirror chart repositories
 *command* [*args*]
 
 # DESCRIPTION
-**mirror** is a [Helm][1] plugin that allows the mirroring of a Chart
+**helm-mirror** is a [Helm][1] plugin that allows the mirroring of a Chart
 repository, with the index file and all referenced charts.
 
-**mirror** will allow users to pass through the same options
+**helm-mirror** will allow users to pass through the same options
 as [Helm][1] does to connect to the repository and download the charts.
 
-**mirror** will also allow users to inspect the charts and extract from them the
+**helm-mirror** will also allow users to inspect the charts and extract from them the
 container images that they use. This will be allowed by the sub-command
-**mirror-inspect-images**(1).
+**helm-mirror-inspect-images**(1).
 
 The index file is a yaml that contains a list of charts in this format.
 Example:
@@ -75,8 +77,14 @@ into your destination folder.
 **--cert-file**
   Identify HTTPS client using this SSL certificate file
 
+**--chart-name**
+  Name of the desired chart to download
+
+**--chart-version**
+  Version of the desired chart to download, needs the `--chart-name` option
+
 **-i, --ignore-errors**
-  Ignores errors while downloading or processing charts.
+  Ignores errors while downloading or processing charts
 
 **--key-file**
   Identify HTTPS client using this SSL key file
@@ -93,26 +101,40 @@ into your destination folder.
 # COMMANDS
 
 **inspect-images**
-  Extract the images from the a target. See **mirror-inspect-images**(1) for more detailed usage
+  Extract the images from the a target. See **helm-mirror-inspect-images**(1) for more detailed usage
   information.
 
 **version**
-  Print current version of software. See **mirror-version**(1) for more detailed
+  Print current version of software. See **helm-mirror-version**(1) for more detailed
   usage information.
 
 **help**
-  Print usage statements. See **mirror-help**(1)
+  Print usage statements. See **helm-mirror-help**(1)
   for more detailed usage information.
 
-# EXAMPLE
+# EXAMPLES
 This will read the given chart repository and download all the Charts that are found into the
 given target folder. target folder has to be always an absolute path.
 
-`% helm mirror https://yourorg.com/charts /yourorg/charts`
+`% helm-mirror https://yourorg.com/charts /yourorg/charts`
+
+This will download all the charts and all the available versions
+of the charts.
+
+`% helm-mirror https://yourorg.com/charts /yourorg/charts --all-charts`
+
+This will download the latest version of the chart `nginx`.
+
+`% helm-mirror https://yourorg.com/charts /yourorg/charts --chart-name nginx`
+
+This will download the version `2.14.3` of the chart `nginx`.
+
+`% helm-mirror https://yourorg.com/charts /yourorg/charts --chart-name nginx --chart-version 2.14.3`
+
 
 # SEE ALSO
-**mirror-inspect-images**(1),
-**mirror-help**(1),
-**mirror-version**(1)
+**helm-mirror-inspect-images**(1),
+**helm-mirror-help**(1),
+**helm-mirror-version**(1)
 
 [1]: https://docs.helm.sh

--- a/fixtures/test_utils.go
+++ b/fixtures/test_utils.go
@@ -4,15 +4,19 @@ import (
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // StartHTTPServer start http server for tests
 func StartHTTPServer() *http.Server {
 	srv := &http.Server{Addr: ":1793"}
+	http.HandleFunc("/alive", aliveTest)
 	http.HandleFunc("/index.yaml", indexFile)
 	http.HandleFunc("/chart1-2.11.0.tgz", chartTgz)
 	http.HandleFunc("/chart2-1.0.1.tgz", chartTgz)
-	http.HandleFunc("/chart2-0.0.0-pre.tgz", chartTgz)
+	http.HandleFunc("/chart2-0.0.0-rc1.tgz", chartTgz)
+	http.HandleFunc("/chart3-0.0.1-rc1.tgz", chartTgz)
 	go func() {
 		if err := srv.ListenAndServe(); err != nil {
 			log.Printf("Httpserver: ListenAndServe() error: %s", err)
@@ -22,18 +26,24 @@ func StartHTTPServer() *http.Server {
 }
 
 // WaitForServer waits until the server is up
-func WaitForServer(url string) {
+func WaitForServer(url string) error {
 	var retry = 10
 	for i := 0; i < retry; i++ {
 		resp, err := http.Get(url)
 		if err != nil {
-			time.Sleep(2)
+			time.Sleep(2 * time.Second)
 			continue
 		}
 		if resp.StatusCode == http.StatusOK {
-			return
+			return nil
 		}
 	}
+	return errors.New("No server available")
+}
+
+func aliveTest(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text")
+	w.WriteHeader(http.StatusOK)
 }
 
 func indexFile(w http.ResponseWriter, r *http.Request) {
@@ -50,7 +60,7 @@ var chartTGZ = []byte{31, 139, 8, 0, 224, 223, 181, 91, 0, 3, 237, 193, 1, 13, 0
 	160, 247, 79, 109, 14, 55, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 55, 3, 154, 222, 29, 39, 0, 40, 0, 0}
 
 //Expectedcharts How many charts are in the test file
-var Expectedcharts = 4
+var Expectedcharts = 5
 
 //IndexYaml test index file
 var IndexYaml = `apiVersion: v1
@@ -66,7 +76,7 @@ entries:
     version: 2.11.0
   chart2:
   - apiVersion: v1
-    created: 2018-09-20T00:00:00.000000000Z
+    created: 2018-10-20T00:00:00.000000000Z
     description: A Helm chart for testing too
     digest: 0c76ee9b4b78cb60fcce8c00ec0f5048cbe626fcaabe48f2f8e84b029e894f49
     name: chart2
@@ -79,14 +89,24 @@ entries:
     digest: e9a545006570b7fc5e4458f6eae178c2aa8f8e9e57eafac59869c856b86e862f
     name: chart2
     urls:
-    - http://127.0.0.1:1793/chart2-0.0.0-pre.tgz
-    version: 0.0.0-pre
+    - http://127.0.0.1:1793/chart2-0.0.0-rc1.tgz
+    version: 0.0.0-rc1
+  chart3:
+  - apiVersion: v1
+    created: 2018-12-18T00:00:00.000000000Z
+    description: A Helm chart that does exist
+    digest: f9a848106870c7fc8f4488f6faf178c2aa8f8f9f87fafac89819c886c86e862f
+    name: chart3
+    urls:
+    - http://127.0.0.1:1793/chart3-0.0.1-rc1.tgz
+    version: 0.0.1-rc1
+  chart4:
   - apiVersion: v1
     created: 2018-12-18T00:00:00.000000000Z
     description: A Helm chart that does not exist
     digest: f9a848106870c7fc8f4488f6faf178c2aa8f8f9f87fafac89819c886c86e862f
     name: chart3
     urls:
-    - http://127.0.0.1:1793/chart3-0.0.1-pre.tgz
-    version: 0.0.1-pre
+    - http://127.0.0.1:1793/chart4-0.0.1.tgz
+    version: 0.0.1-rc1
 `

--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -102,12 +102,9 @@ installFile() {
   rm -rf "$HELM_TMP"
   mkdir -p "$HELM_TMP"
   tar xf "$PLUGIN_TMP_FILE" -C "$HELM_TMP" --strip-components=1
-  HELM_TMP_BIN="$HELM_TMP/bin/mirror"
   echo "Preparing to install into ${HELM_PLUGIN_PATH}"
   mkdir -p "$HELM_PLUGIN_PATH/bin"
   pushd "$HELM_TMP"
-  # make mirror
-#  cp "$HELM_TMP_BIN" "$HELM_PLUGIN_PATH/bin"
   cp -r $HELM_TMP/* "$HELM_PLUGIN_PATH"
   popd
 }
@@ -126,7 +123,7 @@ fail_trap() {
 testVersion() {
   set +e
   echo "$PROJECT_NAME installed into $HELM_PLUGIN_PATH"
-  $HELM_PLUGIN_PATH/bin/mirror version
+  $HELM_PLUGIN_PATH/bin/helm-mirror version
   set -e
 }
 

--- a/service/get_test.go
+++ b/service/get_test.go
@@ -38,17 +38,19 @@ func TestNewGetService(t *testing.T) {
 		logger       *log.Logger
 		newRootURL   string
 		allVersions  bool
+		chartName    string
+		chartVersion string
 	}
 	tests := []struct {
 		name string
 		args args
 		want GetServiceInterface
 	}{
-		{"1", args{"http://helmrepo", dir, false, false, fakeLogger, "https://newchartserver.com", false}, gService},
+		{"1", args{"http://helmrepo", dir, false, false, fakeLogger, "https://newchartserver.com", false, "", ""}, gService},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewGetService(config, tt.args.verbose, tt.args.allVersions, tt.args.ignoreErrors, tt.args.logger, tt.args.newRootURL); !reflect.DeepEqual(got, tt.want) {
+			if got := NewGetService(config, tt.args.verbose, tt.args.allVersions, tt.args.ignoreErrors, tt.args.logger, tt.args.newRootURL, tt.args.chartName, tt.args.chartVersion); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewGetService() = %v, want %v", got, tt.want)
 			}
 		})
@@ -62,24 +64,37 @@ func TestGetService_Get(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 	svr := fixtures.StartHTTPServer()
-	fixtures.WaitForServer(svr.Addr)
+	defer svr.Shutdown(nil)
+	fixtures.WaitForServer("http://127.0.0.1:1793/alive")
 	type fields struct {
 		repoURL      string
 		workDir      string
 		ignoreErrors bool
 		verbose      bool
 		allVersions  bool
+		chartName    string
+		chartVersion string
 	}
 	tests := []struct {
 		name    string
 		fields  fields
 		wantErr bool
+		wantTgz int
 	}{
-		{"1", fields{"", "", false, false, true}, true},
-		{"2", fields{"http://127.0.0.1", "", false, false, true}, true},
-		{"3", fields{"http://127.0.0.1:1793", "", false, false, true}, true},
-		{"4", fields{"http://127.0.0.1:1793", path.Join(dir, "get"), false, false, true}, true},
-		{"5", fields{"http://127.0.0.1:1793", path.Join(dir, "get"), true, false, true}, false},
+		{"1", fields{"", "", false, false, true, "", ""}, true, 0},
+		{"2", fields{"http://127.0.0.1", "", false, false, true, "", ""}, true, 0},
+		{"3", fields{"http://127.0.0.1:1793", "", false, false, true, "", ""}, true, 0},
+		{"4", fields{"http://127.0.0.1:1793", path.Join(dir, "get"), false, false, true, "", ""}, true, 0},
+		{"5", fields{"http://127.0.0.1:1793", path.Join(dir, "get"), true, false, true, "", ""}, false, 4},
+		{"6", fields{"http://127.0.0.1:1793", path.Join(dir, "get"), true, false, false, "", ""}, false, 3},
+		{"7", fields{"http://127.0.0.1:1793", path.Join(dir, "get"), true, true, false, "", ""}, false, 3},
+		{"8", fields{"http://127.0.0.1:1793", path.Join(dir, "get"), true, true, false, "chart2", ""}, false, 1},
+		{"9", fields{"http://127.0.0.1:1793", path.Join(dir, "get"), true, true, false, "chart", ""}, false, 0},
+		{"10", fields{"http://127.0.0.1:1793", path.Join(dir, "get"), true, true, false, `^(?:(?:aa)|.$`, ""}, true, 0},
+		{"11", fields{"http://127.0.0.1:1793", path.Join(dir, "get"), true, true, false, "chart2", "7.0.0"}, false, 0},
+		{"12", fields{"http://127.0.0.1:1793", path.Join(dir, "get"), true, true, false, "chart2", "0.0.0-rc1"}, false, 1},
+		{"13", fields{"http://127.0.0.1:1793", path.Join(dir, "get"), true, true, true, "chart2", ""}, false, 2},
+		{"14", fields{"http://127.0.0.1:1793", path.Join(dir, "get"), true, true, true, "chart2", "0.0.0-rc1"}, false, 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -89,35 +104,52 @@ func TestGetService_Get(t *testing.T) {
 				ignoreErrors: tt.fields.ignoreErrors,
 				verbose:      tt.fields.verbose,
 				allVersions:  tt.fields.allVersions,
+				chartName:    tt.fields.chartName,
+				chartVersion: tt.fields.chartVersion,
 			}
 			if err := g.Get(); (err != nil) != tt.wantErr {
 				t.Errorf("GetService.Get() error = %v, wantErr %v", err, tt.wantErr)
 			}
+			if !tt.wantErr {
+				files, err := ioutil.ReadDir(path.Join(dir, "get"))
+				if err != nil {
+					log.Fatal(err)
+				}
+				count := 0
+				for _, f := range files {
+					if strings.Contains(f.Name(), ".tgz") {
+						count++
+					}
+					os.RemoveAll(path.Join(dir, "get", f.Name()))
+				}
+				if count != tt.wantTgz {
+					t.Errorf("GetService.Get() got count of = %v TGZ files, want count of %v", count, tt.wantTgz)
+				}
+			}
 		})
 	}
 	os.RemoveAll("downloaded-index.yaml")
-	if err := svr.Shutdown(nil); err != nil {
-		t.Errorf("error stoping down web server")
-	}
 }
 
 func Test_writeFile(t *testing.T) {
 	type args struct {
-		name    string
-		content []byte
-		log     *log.Logger
+		name         string
+		content      []byte
+		log          *log.Logger
+		ignoreErrors bool
 	}
 	tests := []struct {
 		name    string
 		args    args
 		wantErr bool
 	}{
-		{"1", args{"tmp.txt", []byte("test"), fakeLogger}, false},
-		{"2", args{"", []byte("test"), fakeLogger}, true},
+		{"1", args{"tmp.txt", []byte("test"), fakeLogger, false}, false},
+		{"2", args{"", []byte("test"), fakeLogger, false}, true},
+		{"2", args{"", []byte("test"), fakeLogger, true}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := writeFile(tt.args.name, tt.args.content, tt.args.log); (err != nil) != tt.wantErr {
+			if err := writeFile(tt.args.name, tt.args.content, tt.args.log, tt.args.ignoreErrors); (err != nil) != tt.wantErr {
 				t.Errorf("writeFile() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -132,24 +164,25 @@ func Test_prepareIndexFile(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 	type args struct {
-		folder     string
-		URL        string
-		newRootURL string
-		log        *log.Logger
+		folder       string
+		URL          string
+		newRootURL   string
+		log          *log.Logger
+		ignoreErrors bool
 	}
 	tests := []struct {
 		name    string
 		args    args
 		wantErr bool
 	}{
-		{"1", args{path.Join(dir, "processfolder"), "http://127.0.0.1:1793", "http://newchart.server.com", fakeLogger}, false},
-		{"2", args{path.Join(dir, "processerrorfolder"), "http://127.0.0.1:1793", "http://newchart.server.com", fakeLogger}, true},
-		{"3", args{path.Join(dir, "processfolder"), "http://127.0.0.1:1793", "", fakeLogger}, false},
+		{"1", args{path.Join(dir, "processfolder"), "http://127.0.0.1:1793", "http://newchart.server.com", fakeLogger, false}, false},
+		{"2", args{path.Join(dir, "processerrorfolder"), "http://127.0.0.1:1793", "http://newchart.server.com", fakeLogger, false}, true},
+		{"3", args{path.Join(dir, "processfolder"), "http://127.0.0.1:1793", "", fakeLogger, false}, false},
 	}
 	for _, tt := range tests {
 		ioutil.WriteFile(path.Join(dir, "processfolder", "downloaded-index.yaml"), []byte(fixtures.IndexYaml), 0666)
 		t.Run(tt.name, func(t *testing.T) {
-			if err := prepareIndexFile(tt.args.folder, tt.args.URL, tt.args.newRootURL, tt.args.log); (err != nil) != tt.wantErr {
+			if err := prepareIndexFile(tt.args.folder, tt.args.URL, tt.args.newRootURL, tt.args.log, tt.args.ignoreErrors); (err != nil) != tt.wantErr {
 				t.Errorf("prepareIndexFile() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.name == "1" {
@@ -160,7 +193,7 @@ func Test_prepareIndexFile(t *testing.T) {
 				content := string(contentBytes)
 				count := strings.Count(content, tt.args.newRootURL)
 				if count != fixtures.Expectedcharts {
-					t.Errorf("prepareIndexFile() replacedCount = %v, want replacedCount %v", count, 3)
+					t.Errorf("prepareIndexFile() replacedCount = %v, want replacedCount %v", count, fixtures.Expectedcharts)
 				}
 				_, err = os.Stat(path.Join(dir, "processfolder", "downloaded-index.yaml"))
 				if err == nil {

--- a/vendor/k8s.io/helm/cmd/helm/search/search.go
+++ b/vendor/k8s.io/helm/cmd/helm/search/search.go
@@ -1,0 +1,237 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*Package search provides client-side repository searching.
+
+This supports building an in-memory search index based on the contents of
+multiple repositories, and then using string matching or regular expressions
+to find matches.
+*/
+package search
+
+import (
+	"errors"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver"
+	"k8s.io/helm/pkg/repo"
+)
+
+const (
+	sep = "\v"
+	// verSep is a separator for version fields in map keys.
+	verSep = "$$"
+)
+
+// Result is a search result.
+//
+// Score indicates how close it is to match. The higher the score, the longer
+// the distance.
+type Result struct {
+	Name  string
+	Score int
+	Chart *repo.ChartVersion
+}
+
+// Index is a searchable index of chart information.
+type Index struct {
+	lines  map[string]string
+	charts map[string]*repo.ChartVersion
+}
+
+// NewIndex creats a new Index.
+func NewIndex() *Index {
+	return &Index{lines: map[string]string{}, charts: map[string]*repo.ChartVersion{}}
+}
+
+// AddRepo adds a repository index to the search index.
+func (i *Index) AddRepo(rname string, ind *repo.IndexFile, all bool) {
+	ind.SortEntries()
+	for name, ref := range ind.Entries {
+		if len(ref) == 0 {
+			// Skip chart names that have zero releases.
+			continue
+		}
+		// By convention, an index file is supposed to have the newest at the
+		// 0 slot, so our best bet is to grab the 0 entry and build the index
+		// entry off of that.
+		// Note: Do not use filePath.Join since on Windows it will return \
+		//       which results in a repo name that cannot be understood.
+		fname := path.Join(rname, name)
+		if !all {
+			i.lines[fname] = indstr(rname, ref[0])
+			i.charts[fname] = ref[0]
+			continue
+		}
+
+		// If 'all' is set, then we go through all of the refs, and add them all
+		// to the index. This will generate a lot of near-duplicate entries.
+		for _, rr := range ref {
+			versionedName := fname + verSep + rr.Version
+			i.lines[versionedName] = indstr(rname, rr)
+			i.charts[versionedName] = rr
+		}
+	}
+}
+
+// All returns all charts in the index as if they were search results.
+//
+// Each will be given a score of 0.
+func (i *Index) All() []*Result {
+	res := make([]*Result, len(i.charts))
+	j := 0
+	for name, ch := range i.charts {
+		parts := strings.Split(name, verSep)
+		res[j] = &Result{
+			Name:  parts[0],
+			Chart: ch,
+		}
+		j++
+	}
+	return res
+}
+
+// Search searches an index for the given term.
+//
+// Threshold indicates the maximum score a term may have before being marked
+// irrelevant. (Low score means higher relevance. Golf, not bowling.)
+//
+// If regexp is true, the term is treated as a regular expression. Otherwise,
+// term is treated as a literal string.
+func (i *Index) Search(term string, threshold int, regexp bool) ([]*Result, error) {
+	if regexp {
+		return i.SearchRegexp(term, threshold)
+	}
+	return i.SearchLiteral(term, threshold), nil
+}
+
+// calcScore calculates a score for a match.
+func (i *Index) calcScore(index int, matchline string) int {
+
+	// This is currently tied to the fact that sep is a single char.
+	splits := []int{}
+	s := rune(sep[0])
+	for i, ch := range matchline {
+		if ch == s {
+			splits = append(splits, i)
+		}
+	}
+
+	for i, pos := range splits {
+		if index > pos {
+			continue
+		}
+		return i
+	}
+	return len(splits)
+}
+
+// SearchLiteral does a literal string search (no regexp).
+func (i *Index) SearchLiteral(term string, threshold int) []*Result {
+	term = strings.ToLower(term)
+	buf := []*Result{}
+	for k, v := range i.lines {
+		lk := strings.ToLower(k)
+		lv := strings.ToLower(v)
+		res := strings.Index(lv, term)
+		if score := i.calcScore(res, lv); res != -1 && score < threshold {
+			parts := strings.Split(lk, verSep) // Remove version, if it is there.
+			buf = append(buf, &Result{Name: parts[0], Score: score, Chart: i.charts[k]})
+		}
+	}
+	return buf
+}
+
+// SearchRegexp searches using a regular expression.
+func (i *Index) SearchRegexp(re string, threshold int) ([]*Result, error) {
+	matcher, err := regexp.Compile(re)
+	if err != nil {
+		return []*Result{}, err
+	}
+	buf := []*Result{}
+	for k, v := range i.lines {
+		ind := matcher.FindStringIndex(v)
+		if len(ind) == 0 {
+			continue
+		}
+		if score := i.calcScore(ind[0], v); ind[0] >= 0 && score < threshold {
+			parts := strings.Split(k, verSep) // Remove version, if it is there.
+			buf = append(buf, &Result{Name: parts[0], Score: score, Chart: i.charts[k]})
+		}
+	}
+	return buf, nil
+}
+
+// Chart returns the ChartVersion for a particular name.
+func (i *Index) Chart(name string) (*repo.ChartVersion, error) {
+	c, ok := i.charts[name]
+	if !ok {
+		return nil, errors.New("no such chart")
+	}
+	return c, nil
+}
+
+// SortScore does an in-place sort of the results.
+//
+// Lowest scores are highest on the list. Matching scores are subsorted alphabetically.
+func SortScore(r []*Result) {
+	sort.Sort(scoreSorter(r))
+}
+
+// scoreSorter sorts results by score, and subsorts by alpha Name.
+type scoreSorter []*Result
+
+// Len returns the length of this scoreSorter.
+func (s scoreSorter) Len() int { return len(s) }
+
+// Swap performs an in-place swap.
+func (s scoreSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+// Less compares a to b, and returns true if a is less than b.
+func (s scoreSorter) Less(a, b int) bool {
+	first := s[a]
+	second := s[b]
+
+	if first.Score > second.Score {
+		return false
+	}
+	if first.Score < second.Score {
+		return true
+	}
+	if first.Name == second.Name {
+		v1, err := semver.NewVersion(first.Chart.Version)
+		if err != nil {
+			return true
+		}
+		v2, err := semver.NewVersion(second.Chart.Version)
+		if err != nil {
+			return true
+		}
+		// Sort so that the newest chart is higher than the oldest chart. This is
+		// the opposite of what you'd expect in a function called Less.
+		return v1.GreaterThan(v2)
+	}
+	return first.Name < second.Name
+}
+
+func indstr(name string, ref *repo.ChartVersion) string {
+	i := ref.Name + sep + name + "/" + ref.Name + sep +
+		ref.Description + sep + strings.Join(ref.Keywords, " ")
+	return i
+}


### PR DESCRIPTION
New features: get latest and specific charts

Getting charts now only downloads the altest versions of the charts.
The --all-versions flags allows to download all versions of the charts.
The flags --chart-name and --chart-version allow the user to only get the desired chart.

https://github.com/SUSE/avant-garde/issues/865

Signed-off-by: Vicente Zepeda Mas <vzepedamas@suse.com>